### PR TITLE
Merge the newer changes to django-cache-machine into our patch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,4 @@ env:
   - DJANGO_SPEC="Django>=1.4,<1.5"
   - DJANGO_SPEC="Django>=1.5,<1.6"
   - DJANGO_SPEC="Django>=1.6,<1.7"
-  - DJANGO_SPEC="https://www.djangoproject.com/download/1.7c1/tarball/"
+  - DJANGO_SPEC="Django>=1.7,<1.8"

--- a/caching/__init__.py
+++ b/caching/__init__.py
@@ -1,2 +1,2 @@
-VERSION = (0, '8', 'dev1')
+VERSION = (0, '8', 'dev2')
 __version__ = '.'.join(map(str, VERSION))

--- a/caching/base.py
+++ b/caching/base.py
@@ -32,7 +32,7 @@ class CachingManager(models.Manager):
     # Tell Django to use this manager when resolving foreign keys.
     use_for_related_fields = True
 
-    def get_query_set(self):
+    def get_queryset(self):
         return CachingQuerySet(self.model, using=self._db)
 
     def contribute_to_class(self, cls, name):
@@ -56,7 +56,7 @@ class CachingManager(models.Manager):
                                   using=self._db, *args, **kwargs)
 
     def cache(self, timeout=DEFAULT_TIMEOUT):
-        return self.get_query_set().cache(timeout)
+        return self.get_queryset().cache(timeout)
 
     def no_cache(self):
         return self.cache(NO_CACHE)

--- a/caching/base.py
+++ b/caching/base.py
@@ -1,6 +1,7 @@
 import functools
 import logging
 
+import django
 from django.conf import settings
 from django.db import models
 from django.db.models import signals
@@ -34,6 +35,9 @@ class CachingManager(models.Manager):
 
     def get_queryset(self):
         return CachingQuerySet(self.model, using=self._db)
+
+    if django.VERSION < (1, 6):
+        get_query_set = get_queryset
 
     def contribute_to_class(self, cls, name):
         signals.post_save.connect(self.post_save, sender=cls)

--- a/caching/invalidation.py
+++ b/caching/invalidation.py
@@ -5,9 +5,11 @@ import logging
 import socket
 
 from django.conf import settings
-from django.core.cache import cache as default_cache, get_cache
+from django.core.cache import cache as default_cache
+from django.core.cache import get_cache
 from django.core.cache.backends.base import InvalidCacheBackendError
 from django.utils import encoding, translation
+from django.utils.six.moves.urllib.parse import parse_qsl
 
 try:
     import redis as redislib
@@ -188,7 +190,8 @@ def parse_backend_uri(backend_uri):
     """
     backend_uri_sliced = backend_uri.split('://')
     if len(backend_uri_sliced) > 2:
-        raise InvalidCacheBackendError("Backend URI can't have more than one scheme://")
+        raise InvalidCacheBackendError(
+            "Backend URI can't have more than one scheme://")
     elif len(backend_uri_sliced) == 2:
         rest = backend_uri_sliced[1]
     else:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -95,7 +95,7 @@ that class and inherit from the :class:`~caching.base.CachingMixin`.  If you
 want related lookups (foreign keys) to hit the cache, ``CachingManager`` must
 be the default manager.  If you have multiple managers that should be cached,
 return a :class:`~caching.base.CachingQuerySet` from the other manager's
-``get_query_set`` method instead of subclassing ``CachingManager``, since that
+``get_queryset`` method instead of subclassing ``CachingManager``, since that
 would hook up the post_save and post_delete signals multiple times.
 
 Here's what a minimal cached model looks like::

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -102,7 +102,7 @@ Here's what a minimal cached model looks like::
 
     from django.db import models
 
-    from caching.base imoprt CachingManager, CachingMixin
+    from caching.base import CachingManager, CachingMixin
 
     class Zomg(CachingMixin, models.Model):
         val = models.IntegerField()


### PR DESCRIPTION
This way we won't have RemovedInDjango18 warnings all over the place. CIrcle CI doesn't like trying to install from my account when it has been used to installing from Ben's so the easiest thing to do would be to merge it here and update the requirements file with the new commit hash.
